### PR TITLE
2017-03-02 AC: Adds Docker support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.buildpath
+.idea/
+.project
+.settings/
+deployment.properties
+deployment.xml

--- a/docs/dockerfiles/bin/xampp-deploy.bash
+++ b/docs/dockerfiles/bin/xampp-deploy.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+export PATH=/opt/lampp/bin:$PATH
+mv /opt/lampp/htdocs /opt/lampp/htdocs.OLD
+cd /opt/lampp
+ln -s /www htdocs
+cd
+/opt/lampp/lampp start
+sleep 5
+/bin/bash
+exit 0

--- a/docs/dockerfiles/run-5.6.28.bash
+++ b/docs/dockerfiles/run-5.6.28.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+docker run --rm -it \
+  -v ${PWD}/../../:/www \
+  -p 5555:80 \
+  -p 10443:443 \
+  -p 13306:3306 \
+  -p 10022:22 \
+  andrewscaya/debian-xampp-5.6.28 \
+  /www/docs/dockerfiles/bin/xampp-deploy.bash run

--- a/docs/dockerfiles/run-7.0.13.bash
+++ b/docs/dockerfiles/run-7.0.13.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+docker run --rm -it \
+  -v ${PWD}/../../:/www \
+  -p 7777:80 \
+  -p 10444:443 \
+  -p 13307:3306 \
+  -p 10023:22 \
+  andrewscaya/debian-xampp-7.0.13 \
+  /www/docs/dockerfiles/bin/xampp-deploy.bash run

--- a/docs/dockerfiles/run-7.1.1.bash
+++ b/docs/dockerfiles/run-7.1.1.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+docker run --rm -it \
+  -v ${PWD}/../../:/www \
+  -p 9999:80 \
+  -p 10445:443 \
+  -p 13308:3306 \
+  -p 10024:22 \
+  andrewscaya/debian-xampp-7.1.1 \
+  /www/docs/dockerfiles/bin/xampp-deploy.bash run

--- a/php7_docker.bash
+++ b/php7_docker.bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+cd docs/dockerfiles
+gnome-terminal -e ./run-5.6.28.bash
+gnome-terminal -e ./run-7.0.13.bash
+gnome-terminal -e ./run-7.1.1.bash
+cd
+echo -e "***********************************************"
+echo -e "PHP 5.6 is running on port 5555\nPHP 7.0 is running on port 7777\nPHP 7.1 is running on port 9999\n"
+echo -e "To stop the Docker containers, just type 'exit'"
+echo -e "and press enter in each terminal window."
+echo -e "***********************************************"
+exit 0


### PR DESCRIPTION
Doug --

Here is the pull request in order to add Docker support to this repo.

Prerequisites : 
* docker-engine must be installed on your computer/VM ([Docker Installation](https://docs.docker.com/engine/installation/linux/debian/)),
* gnome-terminal must be installed (if not - ex. KDE's Konsole, Mac or Windows -, the scripts in the directory 'docs/dockerfiles' - i.e. run-5.6.28.bash, run-7.0.13.bash and run-7.1.1.bash - must be run manually in three different terminal windows).

Commands (Linux with Gnome Terminal) : 
$ cd php7_examples
$ ./php7_docker.bash

PHP versions 5.6, 7.0, 7.1 will then be running on localhost's ports 5555, 7777 and 9999 respectively.

To stop the Docker containers, you just need to type 'exit' and press enter inside each chroot environment (in each terminal window).

If you have any questions, please do not hesitate in sending them to me.

Have a lot of fun! :)

Yours,

Andrew
